### PR TITLE
Use fixtures in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from pathlib import Path
+import fastapi_chameleon as fc
+
+
+@pytest.fixture
+def test_templates_path(pytestconfig):
+    return Path(pytestconfig.rootdir, "tests", "templates")
+
+
+@pytest.fixture
+def setup_global_template(test_templates_path):
+    fc.global_init(str(test_templates_path))
+    yield
+    # Clear paths so as to no affect future tests
+    fc.engine.clear()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,16 +1,11 @@
-import os
-
 import pytest
 
 import fastapi_chameleon as fc
 from fastapi_chameleon.exceptions import FastAPIChameleonException
 
-here = os.path.dirname(__file__)
-folder = os.path.join(here, 'templates')
-
 
 def test_cannot_decorate_with_missing_init():
-    fc.engine.template_path = None
+    fc.engine.clear()
 
     with pytest.raises(FastAPIChameleonException):
         @fc.template('home/index.pt')
@@ -20,10 +15,14 @@ def test_cannot_decorate_with_missing_init():
         view_method(1, 2, 3)
 
 
-def test_can_call_init_with_good_path():
-    fc.global_init(folder, cache_init=False)
+def test_can_call_init_with_good_path(test_templates_path):
+    fc.global_init(str(test_templates_path), cache_init=False)
+
+    # Clear paths so as to no affect future tests
+    fc.engine.clear()
 
 
-def test_cannot_call_init_with_bad_path():
+def test_cannot_call_init_with_bad_path(test_templates_path):
+    bad_path = test_templates_path / "missing"
     with pytest.raises(Exception):
-        fc.global_init(folder + 'missing', cache_init=False)
+        fc.global_init(str(bad_path), cache_init=False)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,15 +1,11 @@
 import asyncio
-import os
 
 import fastapi
 # noinspection PyPackageRequirements
 import pytest
 
 import fastapi_chameleon as fc
-from fastapi_chameleon.exceptions import FastAPIChameleonException
 
-here = os.path.dirname(__file__)
-folder = os.path.join(here, 'templates')
 
 def test_cannot_decorate_missing_template(setup_global_template):
     with pytest.raises(ValueError):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -11,8 +11,7 @@ from fastapi_chameleon.exceptions import FastAPIChameleonException
 here = os.path.dirname(__file__)
 folder = os.path.join(here, 'templates')
 
-
-def test_cannot_decorate_missing_template():
+def test_cannot_decorate_missing_template(setup_global_template):
     with pytest.raises(ValueError):
         @fc.template('home/missing.pt')
         def view_method():
@@ -21,7 +20,7 @@ def test_cannot_decorate_missing_template():
         view_method()
 
 
-def test_requires_template_for_default_name():
+def test_requires_template_for_default_name(setup_global_template):
     with pytest.raises(ValueError):
         @fc.template(None)
         def view_method():
@@ -30,7 +29,7 @@ def test_requires_template_for_default_name():
         view_method()
 
 
-def test_default_template_name_pt():
+def test_default_template_name_pt(setup_global_template):
     @fc.template()
     def index(a, b, c):
         return {'a': a, 'b': b, 'c': c, 'world': 'WORLD'}
@@ -42,7 +41,7 @@ def test_default_template_name_pt():
     assert '<h1>Hello default WORLD!</h1>' in html
 
 
-def test_default_template_name_no_parentheses():
+def test_default_template_name_no_parentheses(setup_global_template):
     @fc.template
     def index(a, b, c):
         return {'a': a, 'b': b, 'c': c, 'world': 'WORLD'}
@@ -54,7 +53,7 @@ def test_default_template_name_no_parentheses():
     assert '<h1>Hello default WORLD!</h1>' in html
 
 
-def test_default_template_name_html():
+def test_default_template_name_html(setup_global_template):
     @fc.template()
     def details(a, b, c):
         return {'a': a, 'b': b, 'c': c, 'world': 'WORLD'}
@@ -66,7 +65,7 @@ def test_default_template_name_html():
     assert '<h1>Hello default WORLD!</h1>' in html
 
 
-def test_can_decorate_dict_sync_method():
+def test_can_decorate_dict_sync_method(setup_global_template):
     @fc.template('home/index.pt')
     def view_method(a, b, c):
         return {'a': a, 'b': b, 'c': c}
@@ -76,7 +75,7 @@ def test_can_decorate_dict_sync_method():
     assert resp.status_code == 200
 
 
-def test_can_decorate_dict_async_method():
+def test_can_decorate_dict_async_method(setup_global_template):
     @fc.template('home/index.pt')
     async def view_method(a, b, c):
         return {'a': a, 'b': b, 'c': c}


### PR DESCRIPTION
Now each test is isolated and can be run on its own thanks to *pytest* fixtures as discussed in https://github.com/mikeckennedy/fastapi-chameleon/issues/13.