### PR TITLE
Update tox.ini for py3.6+ only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py36,py37,py38,py39
 
 [testenv]
 commands = py.test fastapi-chameleon


### PR DESCRIPTION
Along with the other changes for #15, this should be the last change.