### PR TITLE
Added a more generic error reporting function: generic_error().

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,21 @@ async def item(item_id: int):
 
 This will render a 404 response with using the template file `templates/errors/404.pt`.
 You can specify another template to use for the response, but it's not required.
+
+If you need to return errors other than `Not Found` (status code `404`), you can use a more
+generic function: `fastapi_chameleon.generic_error(template_file: str, status_code: int)`.
+This function will allow you to return different status codes. It's generic, thus you'll have
+to pass a path to your error template file as well as a status code you want the user to get
+in response. For example:
+
+```python
+@router.get('/catalog/item/{item_id}')
+@fastapi_chameleon.template('catalog/item.pt')
+async def item(item_id: int):
+    item = service.get_item_by_id(item_id)
+    if not item:
+        fastapi_chameleon.generic_error('errors/unauthorized.pt',
+                                        fastapi.status.HTTP_401_UNAUTHORIZED)
+
+    return item.dict()
+```

--- a/fastapi_chameleon/__init__.py
+++ b/fastapi_chameleon/__init__.py
@@ -1,6 +1,6 @@
 """fastapi-chameleon - Adds integration of the Chameleon template language to FastAPI."""
 
-__version__ = '0.1.12'
+__version__ = '0.1.13'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = ['template', 'global_init', 'not_found', 'response', ]
 

--- a/fastapi_chameleon/engine.py
+++ b/fastapi_chameleon/engine.py
@@ -6,7 +6,8 @@ from typing import Optional, Union, Callable
 import fastapi
 from chameleon import PageTemplateLoader, PageTemplate
 
-from fastapi_chameleon.exceptions import FastAPIChameleonException, FastAPIChameleonNotFoundException
+from fastapi_chameleon.exceptions import FastAPIChameleonException, FastAPIChameleonGenericException, \
+    FastAPIChameleonNotFoundException
 
 __templates: Optional[PageTemplateLoader] = None
 template_path: Optional[str] = None
@@ -89,6 +90,8 @@ def template(template_file: Optional[Union[Callable, str]] = None, mimetype: str
                 return __render_response(template_file, response_val, mimetype)
             except FastAPIChameleonNotFoundException as nfe:
                 return __render_response(nfe.template_file, {}, 'text/html', 404)
+            except FastAPIChameleonGenericException as nfe:
+                return __render_response(nfe.template_file, {}, 'text/html', nfe.status_code)
 
         @wraps(f)
         async def async_view_method(*args, **kwargs):
@@ -97,6 +100,8 @@ def template(template_file: Optional[Union[Callable, str]] = None, mimetype: str
                 return __render_response(template_file, response_val, mimetype)
             except FastAPIChameleonNotFoundException as nfe:
                 return __render_response(nfe.template_file, {}, 'text/html', 404)
+            except FastAPIChameleonGenericException as nfe:
+                return __render_response(nfe.template_file, {}, 'text/html', nfe.status_code)
 
         if inspect.iscoroutinefunction(f):
             return async_view_method
@@ -128,3 +133,9 @@ def not_found(four04template_file: str = 'errors/404.pt'):
         raise FastAPIChameleonNotFoundException(msg, four04template_file)
     else:
         raise FastAPIChameleonNotFoundException(msg)
+
+
+def generic_error(template_file: str, status_code: int):
+    msg = 'The URL resulted in an error.'
+
+    raise FastAPIChameleonGenericException(template_file, status_code, msg)

--- a/fastapi_chameleon/exceptions.py
+++ b/fastapi_chameleon/exceptions.py
@@ -11,3 +11,13 @@ class FastAPIChameleonNotFoundException(FastAPIChameleonException):
 
         self.template_file: str = four04template_file
         self.message: Optional[str] = message
+
+
+class FastAPIChameleonGenericException(FastAPIChameleonException):
+    def __init__(self, template_file: str, status_code: int,
+                 message: Optional[str] = None):
+        super().__init__(message)
+
+        self.template_file: str = template_file
+        self.status_code: int = status_code
+        self.message: Optional[str] = message

--- a/tests/test_generic_error.py
+++ b/tests/test_generic_error.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import fastapi
+import pytest
+
+import fastapi_chameleon
+import fastapi_chameleon as fc
+
+
+# setup_global_template - needed as pytest mix-in.
+# noinspection PyUnusedLocal
+@pytest.mark.parametrize(
+    ("status_code", "template_file", "expected_h1_in_body"),
+    [
+        (fastapi.status.HTTP_400_BAD_REQUEST, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_401_UNAUTHORIZED, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_403_FORBIDDEN, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_404_NOT_FOUND, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_405_METHOD_NOT_ALLOWED, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_406_NOT_ACCEPTABLE, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_407_PROXY_AUTHENTICATION_REQUIRED, "errors/404.pt",
+         b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_408_REQUEST_TIMEOUT, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+    ],
+)
+def test_friendly_403_sync_method(setup_global_template, status_code, template_file, expected_h1_in_body):
+    @fc.template('home/index.pt')
+    def view_method(a, b, c):
+        fastapi_chameleon.generic_error(template_file, status_code)
+        return {'a': a, 'b': b, 'c': c}
+
+    resp = view_method(1, 2, 3)
+    assert isinstance(resp, fastapi.Response)
+    assert resp.status_code == status_code
+    assert expected_h1_in_body in resp.body
+
+
+# setup_global_template - needed as pytest mix-in.
+# noinspection PyUnusedLocal
+@pytest.mark.parametrize(
+    ("status_code", "template_file", "expected_h1_in_body"),
+    [
+        (fastapi.status.HTTP_400_BAD_REQUEST, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_401_UNAUTHORIZED, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_403_FORBIDDEN, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_404_NOT_FOUND, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_405_METHOD_NOT_ALLOWED, "errors/404.pt", b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_406_NOT_ACCEPTABLE, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_407_PROXY_AUTHENTICATION_REQUIRED, "errors/404.pt",
+         b'<h1>This is a pretty 404 page.</h1>'),
+        (fastapi.status.HTTP_408_REQUEST_TIMEOUT, "errors/other_error_page.pt", b'<h1>Another pretty 404 page.</h1>'),
+    ],
+)
+def test_friendly_403_async_method(setup_global_template, status_code, template_file, expected_h1_in_body):
+    @fc.template('home/index.pt')
+    async def view_method(a, b, c):
+        fastapi_chameleon.generic_error(template_file, status_code)
+        return {'a': a, 'b': b, 'c': c}
+
+    resp = asyncio.run(view_method(1, 2, 3))
+    assert isinstance(resp, fastapi.Response)
+    assert resp.status_code == status_code
+    assert expected_h1_in_body in resp.body


### PR DESCRIPTION
First of all, thanks for this great piece of code. Made my life a lot easier by eliminating a lot of boilerplate code. :) :+1: 

I'm working o a project right now that requires me to perform certain authorization operations on various operations. Some operations are permitted only to a certain group of people. For example it would make sense to return a `401` to a user if they are not part of a specific privileged group. Or, maybe there is something specific about a request that makes it simply off-limits always. And in that case returning `403` would fit even better.

Please, take a look at this PR. It's introducing a new function `generic_error()` that allows the user to specify particular details about the error they want to return to the user. For the above examples I'd be able to e.g.:

```python
return fastapi_chameleon.generic_error("errors/my_unauthorized_template.ts", 401)
```

Works just like `not_found()`, but allows to specify the status code.