### PR TITLE
Add data templating to `generic_error`

### DIFF
--- a/fastapi_chameleon/__init__.py
+++ b/fastapi_chameleon/__init__.py
@@ -1,6 +1,6 @@
 """fastapi-chameleon - Adds integration of the Chameleon template language to FastAPI."""
 
-__version__ = '0.1.15'
+__version__ = '0.1.16'
 __author__ = 'Michael Kennedy <michael@talkpython.fm>'
 __all__ = ['template', 'global_init', 'not_found', 'response', 'generic_error', ]
 

--- a/fastapi_chameleon/engine.py
+++ b/fastapi_chameleon/engine.py
@@ -91,7 +91,8 @@ def template(template_file: Optional[Union[Callable, str]] = None, mimetype: str
             except FastAPIChameleonNotFoundException as nfe:
                 return __render_response(nfe.template_file, {}, 'text/html', 404)
             except FastAPIChameleonGenericException as nfe:
-                return __render_response(nfe.template_file, {}, 'text/html', nfe.status_code)
+                template_data = nfe.template_data if not None else {}
+                return __render_response(nfe.template_file, template_data, 'text/html', nfe.status_code)
 
         @wraps(f)
         async def async_view_method(*args, **kwargs):
@@ -101,7 +102,8 @@ def template(template_file: Optional[Union[Callable, str]] = None, mimetype: str
             except FastAPIChameleonNotFoundException as nfe:
                 return __render_response(nfe.template_file, {}, 'text/html', 404)
             except FastAPIChameleonGenericException as nfe:
-                return __render_response(nfe.template_file, {}, 'text/html', nfe.status_code)
+                template_data = nfe.template_data if not None else {}
+                return __render_response(nfe.template_file, template_data, 'text/html', nfe.status_code)
 
         if inspect.iscoroutinefunction(f):
             return async_view_method
@@ -135,7 +137,7 @@ def not_found(four04template_file: str = 'errors/404.pt'):
         raise FastAPIChameleonNotFoundException(msg)
 
 
-def generic_error(template_file: str, status_code: int):
+def generic_error(template_file: str, status_code: int, template_data: Optional[dict] = None):
     msg = 'The URL resulted in an error.'
 
-    raise FastAPIChameleonGenericException(template_file, status_code, msg)
+    raise FastAPIChameleonGenericException(template_file, status_code, msg, template_data=template_data)

--- a/fastapi_chameleon/exceptions.py
+++ b/fastapi_chameleon/exceptions.py
@@ -15,9 +15,10 @@ class FastAPIChameleonNotFoundException(FastAPIChameleonException):
 
 class FastAPIChameleonGenericException(FastAPIChameleonException):
     def __init__(self, template_file: str, status_code: int,
-                 message: Optional[str] = None):
+                 message: Optional[str] = None, template_data: Optional[dict] = None):
         super().__init__(message)
 
         self.template_file: str = template_file
         self.status_code: int = status_code
         self.message: Optional[str] = message
+        self.template_data: Optional[dict] = template_data

--- a/tests/templates/errors/error_with_data.pt
+++ b/tests/templates/errors/error_with_data.pt
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p tal:content="test_data"></p>
+    </body>
+</html>

--- a/tests/test_generic_error_data.py
+++ b/tests/test_generic_error_data.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import fastapi
+import pytest
+
+import fastapi_chameleon
+import fastapi_chameleon as fc
+
+@pytest.mark.parametrize(
+    ("status_code", "template_file", "template_data", "expected_p_in_body"),
+    [
+        (fastapi.status.HTTP_400_BAD_REQUEST, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_401_UNAUTHORIZED, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_402_PAYMENT_REQUIRED, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_403_FORBIDDEN, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_404_NOT_FOUND, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+    ]
+)
+def test_data_friendly_generic_sync(setup_global_template, status_code,
+                                    template_file, template_data, expected_p_in_body):
+    @fc.template('home/index.pt')
+    def view_method(a, b, c):
+        fastapi_chameleon.generic_error(template_file, status_code, template_data=template_data)
+        return {'a': a, 'b': b, 'c': c}
+
+    resp = view_method(1, 2, 3)
+    assert isinstance(resp, fastapi.Response)
+    assert resp.status_code == status_code
+    assert expected_p_in_body in resp.body
+
+
+@pytest.mark.parametrize(
+    ("status_code", "template_file", "template_data", "expected_p_in_body"),
+    [
+        (fastapi.status.HTTP_400_BAD_REQUEST, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_401_UNAUTHORIZED, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_402_PAYMENT_REQUIRED, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_403_FORBIDDEN, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+        (fastapi.status.HTTP_404_NOT_FOUND, "errors/error_with_data.pt",
+         {"test_data": "this error is given with data"}, b"<p>this error is given with data</p>"),
+    ]
+)
+def test_data_friendly_generic_async(setup_global_template, status_code,
+                                    template_file, template_data, expected_p_in_body):
+    @fc.template('home/index.pt')
+    async def view_method(a, b, c):
+        fastapi_chameleon.generic_error(template_file, status_code, template_data=template_data)
+        return {'a': a, 'b': b, 'c': c}
+
+    resp = asyncio.run(view_method(1, 2, 3))
+    assert isinstance(resp, fastapi.Response)
+    assert resp.status_code == status_code
+    assert expected_p_in_body in resp.body
+


### PR DESCRIPTION
Data templating is now possible with `generic_error` in a way that does not break compatibility with existing versions. I did bump the patch version number to 16 from 15, but this can be reverted if need be. Feedback is welcome and I would appreciate any checks you have that I might've missed. Note that my tests passed with warnings on Python 3.12.7 (Arch Linux distrib.), but other tests that were not relevant to my changes did not. Python 3.12 could be added to the compatibility list if these tests were to pass, even with some deprecation warnings.

Fixes #26